### PR TITLE
Add abilitiy to subscribe to changes of ViewModel properties

### DIFF
--- a/src/MvvmBlazor/ViewModel/ViewModelBase.cs
+++ b/src/MvvmBlazor/ViewModel/ViewModelBase.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MvvmBlazor.Internal.Bindings;
 
 namespace MvvmBlazor.ViewModel
 {
@@ -50,16 +51,23 @@ namespace MvvmBlazor.ViewModel
            });
         }
 
-        protected void SubscribeAsync<T>(Expression<Func<T>>? expression, Func<T, Task> func)
+        protected void SubscribeAsync<T>(Expression<Func<T>>? property, Func<T, Task> func)
         {
-            var member = expression?.Body as MemberExpression;
-            var propInfo = member?.Member as PropertyInfo;
-            if (propInfo == null)
+            if (property is null)
             {
-                return;
+                throw new BindingException("Property cannot be null");
+            }
+            if (!(property.Body is MemberExpression m))
+            {
+                throw new BindingException("Subscription member must be a property");
             }
 
-            var propertyName = propInfo.Name;
+            if (!(m.Member is PropertyInfo propertyInfo))
+            {
+                throw new BindingException("Subscription member must be a property");
+            }
+            
+            var propertyName = propertyInfo.Name;
             if (!_subscriptions.ContainsKey(propertyName))
             {
                 _subscriptions[propertyName] = new List<Func<object, Task>>();

--- a/src/MvvmBlazor/ViewModel/ViewModelBase.cs
+++ b/src/MvvmBlazor/ViewModel/ViewModelBase.cs
@@ -22,11 +22,11 @@ namespace MvvmBlazor.ViewModel
             {
                 field = value;
                 OnPropertyChanged(propertyName!);
-                if (!_subscriptions.ContainsKey(propertyName))
+                if (!_subscriptions.ContainsKey(propertyName!))
                 {
                     return true;
                 }
-                foreach (var action in _subscriptions[propertyName])
+                foreach (var action in _subscriptions[propertyName!])
                 {
                     action(value!);
                 }


### PR DESCRIPTION
Often times it is useful to react in code to changes on the ViewModel properties within the ViewModel itself. One way to do that is to add code within the setter of that property itself:

```
public class MyViewModel : ViewModelBase
{

   private string _myValue;
   public string MyValue
   {
      get => _myValue;
      set 
      {
         Set(ref _myValue, value);
         DoSomeWork();
      }
}
```

This however is a bit clunky and hard to follow. I think it would be nicer to have an explicit way to Subscribe to changes. This PR introduces the following:

```
public class MyViewModel : ViewModelBase
{
   public MyViewModel()
   {
       Subscribe(() => MyValue, newValue => DoSomeWork());
   }
   private string _myValue;
   public string MyValue
   {
      get => _myValue;
      set => Set(ref _myValue, value);
   }
}
```