### PR TITLE
Add overload for Set<T>() with custom IEqualityComparer

### DIFF
--- a/src/MvvmBlazor.Core/ViewModel/ViewModelBase.cs
+++ b/src/MvvmBlazor.Core/ViewModel/ViewModelBase.cs
@@ -1,4 +1,4 @@
-﻿namespace MvvmBlazor.ViewModel;
+namespace MvvmBlazor.ViewModel;
 
 public abstract class ViewModelBase : INotifyPropertyChanged
 {
@@ -10,7 +10,13 @@ public abstract class ViewModelBase : INotifyPropertyChanged
 
     protected bool Set<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
-        if (!EqualityComparer<T>.Default.Equals(field, value))
+        return Set(ref field, value, EqualityComparer<T>.Default, propertyName);
+    }
+
+    protected bool Set<T>(ref T field, T value, IEqualityComparer<T> equalityComparer, [CallerMemberName] string? propertyName = null)
+    {
+        ArgumentNullException.ThrowIfNull(equalityComparer);
+        if (!equalityComparer.Equals(field, value))
         {
             field = value;
             OnPropertyChanged(propertyName!);

--- a/src/MvvmBlazor.Tests/ViewModel/ViewModelBaseTests.cs
+++ b/src/MvvmBlazor.Tests/ViewModel/ViewModelBaseTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MvvmBlazor.Tests.ViewModel;
+namespace MvvmBlazor.Tests.ViewModel;
 
 public class ViewModelBaseTests
 {

--- a/src/MvvmBlazor.Tests/ViewModel/ViewModelBaseTests.cs
+++ b/src/MvvmBlazor.Tests/ViewModel/ViewModelBaseTests.cs
@@ -77,19 +77,35 @@ public class ViewModelBaseTests
     }
 
     [Fact]
-    public void Set_should_use_custom_equality_comparer()
+    public void Set_returns_False_with_custom_equality_comparer()
     {
-        bool used = false;
-        var mockEq= new Mock<IEqualityComparer<int>>();
+        var mockEq= new StrictMock<IEqualityComparer<int>>();
         mockEq.Setup(x => x.Equals(It.IsAny<int>(), It.IsAny<int>()))
-            .Returns(() => { used = true; return true; });
+            .Returns(true)
+            .Verifiable();
 
         var vm = new TestViewModel();
         var int1 = 1;
         var res = vm.SetProperty(ref int1, 2, mockEq.Object, "Foo");
 
         res.ShouldBe(false);
-        used.ShouldBe(true);
+        mockEq.Verify();
+    }
+
+    [Fact]
+    public void Set_returns_true_with_custom_equality_comparer()
+    {
+        var mockEq= new StrictMock<IEqualityComparer<int>>();
+        mockEq.Setup(x => x.Equals(It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(false)
+            .Verifiable();
+
+        var vm = new TestViewModel();
+        var int1 = 1;
+        var res = vm.SetProperty(ref int1, 1, mockEq.Object, "Foo");
+
+        res.ShouldBe(true);
+        mockEq.Verify();
     }
 
     private class TestViewModel : ViewModelBase

--- a/src/MvvmBlazor.Tests/ViewModel/ViewModelBaseTests.cs
+++ b/src/MvvmBlazor.Tests/ViewModel/ViewModelBaseTests.cs
@@ -76,11 +76,32 @@ public class ViewModelBaseTests
         TestField(ref double1, 2.3);
     }
 
+    [Fact]
+    public void Set_should_use_custom_equality_comparer()
+    {
+        bool used = false;
+        var mockEq= new Mock<IEqualityComparer<int>>();
+        mockEq.Setup(x => x.Equals(It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(() => { used = true; return true; });
+
+        var vm = new TestViewModel();
+        var int1 = 1;
+        var res = vm.SetProperty(ref int1, 2, mockEq.Object, "Foo");
+
+        res.ShouldBe(false);
+        used.ShouldBe(true);
+    }
+
     private class TestViewModel : ViewModelBase
     {
         public bool SetProperty<T>(ref T field, T value, string? propertyName = null)
         {
             return Set(ref field, value, propertyName);
+        }
+
+        public bool SetProperty<T>(ref T field, T value, IEqualityComparer<T> equalityComparer, string? propertyName = null)
+        {
+            return Set(ref field, value, equalityComparer, propertyName);
         }
     }
 }


### PR DESCRIPTION
Enable custom equality testing when setting a property value by directly passing an `IEqualityComparer<T>` to the `ViewModelBase.Set<T>()` function.

Resolves #112 